### PR TITLE
INTEXT-189 Add BeanDefinition Pattern

### DIFF
--- a/src/main/java/org/springframework/integration/aws/s3/config/xml/AmazonS3InboundChannelAdapterParser.java
+++ b/src/main/java/org/springframework/integration/aws/s3/config/xml/AmazonS3InboundChannelAdapterParser.java
@@ -84,7 +84,9 @@ public class AmazonS3InboundChannelAdapterParser extends
 			throw new BeanDefinitionStoreException(message);
 		}
 		else {
-            builder.addPropertyValue("directory", directory);
+        		BeanDefinition expressionDef = IntegrationNamespaceUtils
+					.createExpressionDefinitionFromValueOrExpression("local-directory", "local-directory-expression", parserContext, element, true);
+			builder.addPropertyValue("directory", expressionDef);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, MAX_OBJECTS_PER_BATCH);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, ACCEPT_SUB_FOLDERS);


### PR DESCRIPTION
Resolve the problem that "local-directory" or "local-directory-expression" property-placeholder can not be extracted
